### PR TITLE
Added Apple pay support for Freepay gateway

### DIFF
--- a/src/js/data/dk.js
+++ b/src/js/data/dk.js
@@ -262,7 +262,7 @@ const PSPs = [
         link: 'https://freepay.dk/da/betalingsgateway/priser',
         dankort: true,
         acqs: new Set(['nets', 'clearhaus']),
-        features: new Set(['subscriptions', 'mobilepay']),
+        features: new Set(['subscriptions', 'mobilepay', 'applepay']),
         modules: new Set(['woocommerce', 'magento', 'prestashop', 'opencart']),
         fees: {
             trn(o) {


### PR DESCRIPTION
Freepay gateway supports Apple pay now. Gateway features data is updated to reflect that.